### PR TITLE
Prerelease 2.0.4-rc1

### DIFF
--- a/dash_bootstrap_components/_version.py
+++ b/dash_bootstrap_components/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.4-dev"
+__version__ = "2.0.4-rc1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-bootstrap-components",
-  "version": "2.0.4-dev",
+  "version": "2.0.4-rc1",
   "description": "Bootstrap components for Plotly Dash",
   "repository": "github:dbc-team/dash-bootstrap-components",
   "main": "lib/dash-bootstrap-components.min.js",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,4 +2,4 @@ from dash_bootstrap_components import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.4-dev"
+    assert __version__ == "2.0.4-rc1"


### PR DESCRIPTION
Version 2.0.4 of _dash-bootstrap-components_! This is a patch release fixing a bug in the `Spinner` component.

### Fixed
- Make sure loading spinner only shows when children are loading. ([PR 1140](https://github.com/facultyai/dash-bootstrap-components/pull/1140))