### PR TITLE
Switch to maintained release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,10 @@ jobs:
 
       - name: Create GitHub release
         id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
+          name: ${{ steps.get-release-type.outputs.prefix }} ${{ steps.get-version.outputs.version }}
           tag_name: ${{ steps.get-version.outputs.version }}
-          release_name: ${{ steps.get-release-type.outputs.prefix }} ${{ steps.get-version.outputs.version }}
           body: ${{ github.event.pull_request.body }}
           prerelease: ${{ steps.get-release-type.outputs.type == 'prerelease' }}
 


### PR DESCRIPTION
actions/create-release is unmaintained and recently started failing. Switching
to alternative release action under active development.

